### PR TITLE
couchdb: Allow couchdb to sendto kernel unix domain sockets

### DIFF
--- a/couchdb.te
+++ b/couchdb.te
@@ -65,6 +65,7 @@ can_exec(couchdb_t, couchdb_exec_t)
 
 kernel_read_system_state(couchdb_t)
 kernel_read_fs_sysctls(couchdb_t)
+kernel_dgram_send(couchdb_t)
 
 corecmd_exec_bin(couchdb_t)
 corecmd_exec_shell(couchdb_t)


### PR DESCRIPTION
selinux-policy-3.13.1-103.fc21
This commit fixes an issue where on Fedora 21 couchdb currently fails to start because it cannot `sendto` to systemd.

```
type=AVC msg=audit(1419910248.390:2287): avc:  denied  { sendto } for  pid=32469 comm="beam.smp" path="/run/systemd/notify" scontext=system_u:system_r:couchdb_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=unix_dgram_socket permissive=0
type=SYSCALL msg=audit(1419910248.390:2287): arch=c000003e syscall=46 success=no exit=-13 a0=10 a1=7fa64d3bbc50 a2=4000 a3=1 items=0 ppid=1 pid=32469 auid=4294967295 uid=986 gid=983 euid=986 suid=986 fsuid=986 egid=983 sgid=983 fsgid=983 tty=(none) ses=4294967295 comm="beam.smp" exe="/usr/lib64/erlang/erts-6.3/bin/beam.smp" subj=system_u:system_r:couchdb_t:s0 key=(null)
```