### PR TITLE
openvswitch needs to search network sysctl

### DIFF
--- a/openvswitch.te
+++ b/openvswitch.te
@@ -72,6 +72,7 @@ kernel_read_network_state(openvswitch_t)
 kernel_read_system_state(openvswitch_t)
 kernel_request_load_module(openvswitch_t)
 kernel_read_net_sysctls(openvswitch_t)
+kernel_search_network_sysctl(openvswitch_t)
 
 corenet_tcp_connect_openflow_port(openvswitch_t)
 corenet_tcp_bind_generic_node(openvswitch_t)


### PR DESCRIPTION
openvswitch needs to search network sysctl entries as well as read them.

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1177632